### PR TITLE
Update `SciDecimal.uncertainty()` to correctly scale exponent based on `uncertainty_scale`

### DIFF
--- a/src/decimal.rs
+++ b/src/decimal.rs
@@ -105,15 +105,6 @@ impl From<BiasedExponent> for i16 {
     }
 }
 
-impl Sub<u8> for BiasedExponent {
-    type Output = BiasedExponent;
-
-    fn sub(self, rhs: u8) -> BiasedExponent {
-        BiasedExponent::from(i16::from(self) - i16::from(rhs))
-    }
-}
-
-
 /// A decimal floating point number with an associated uncertainty.
 ///
 /// Represents a number of the form (_m_ ± _u_) × 10<sup><i>n</i></sup>.
@@ -165,7 +156,7 @@ impl SciNumeric for SciDecimal {
             uncertainty: 0,
             uncertainty_scale: 0,
             negative: false,
-            exponent: self.exponent - self.uncertainty_scale,
+            exponent: BiasedExponent(self.exponent.0 - self.uncertainty_scale as u16),
             significand: self.uncertainty.into(),
         }
     }


### PR DESCRIPTION
## The Problem

This code is what gets the uncertainty of a `SciDecimal` (lines 154-162 in pre-fix `decimal.rs`)
```rust
fn uncertainty(&self) -> Self {
    Self {
        uncertainty: 0,
        uncertainty_scale: 0,
        negative: false,
        exponent: self.exponent,
        significand: self.uncertainty.into(),
    }
}
```
except the problem is that it doesn't properly handle `SciDecimal` with a non-zero `uncertainty_scale`. 

## Potential Fix

The fix I implemented is perhaps not perfect, but I think it follows the spirit of what I've seen in other parts of `SciNum`.

The way I understand the point of `SciDecimal.uncertainty_scale` is that it is supposed to be a negative offset relative to the `SciDecimal.exponent`, so that if you have some `uncertainty_scale` and some `exponent`, then the function `SciDecimal.uncertainty()` is supposed to return what is essentially `SciDecimal::new(number, exponent - uncertainty_scale)`.

The fix I decided to implement is relatively simple and doesn't fully cover all possibilities, but should serve as a good starting point. Obviously my first step was to put in a subtraction that implements what I talked about above:
```rust
fn uncertainty(&self) -> Self {
    Self {
        uncertainty: 0,
        uncertainty_scale: 0,
        negative: false,
        exponent: self.exponent - self.uncertainty_scale,
        significand: self.uncertainty.into(),
    }
}
```
and then after this I added the subtraction implementation since `self.exponent` is of type `BiasedExponent` and `self.uncertainty_scale` is of type `u8`. To do this I added the following code:
```rust
impl Sub<u8> for BiasedExponent {
    type Output = BiasedExponent;

    fn sub(self, rhs: u8) -> BiasedExponent {
        BiasedExponent::from(i16::from(self) - i16::from(rhs))
    }
}
```
which handles a large portion of cases. I went with converting both to `i16` since it is a guaranteed safe conversion for both `BiasedExponent` and `u8` and can handle negative values, however I have not gotten to any code to handle an underflow (or overflow, if that is possible).

## Example of Fix in Test

In the case of the code in `powi_with_uncertainty` (lines 1869-1875, pre-fix `decimal.rs`), the problem presents itself because the `result` has `uncertainty=8000` but `uncertainty_scale=2`, therefore the output from `result.uncertainty()` should be equivalent to `SciDecimal::new(8000, -2)`. In actuality, the test does not pass because of the problem presented above, however with the preliminary fix I've suggested, the test passes.

Closes Issue #1 