### PR TITLE
(Partially) implement the `Float` trait for both Sci types

### DIFF
--- a/src/cast.rs
+++ b/src/cast.rs
@@ -1,0 +1,115 @@
+// SPDX-FileCopyrightText: 2026 Matthew Milner <matterhorn103@proton.me>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+use std::cmp::Ordering;
+
+use num_traits::{Float, FromPrimitive, NumCast, ToPrimitive, Zero};
+
+use crate::{RoundingMode, SciDecimal, SciFloat, SciNum};
+
+impl FromPrimitive for SciDecimal {
+    #[inline]
+    fn from_i64(n: i64) -> Option<Self> {
+        if n > Self::MAX_SIGNIFICAND_SIGNED {
+            None
+        } else {
+            Some(Self::new(n, 0))
+        }
+    }
+
+    #[inline]
+    fn from_u64(n: u64) -> Option<Self> {
+        if n > Self::MAX_SIGNIFICAND {
+            None
+        } else {
+            Some(Self::new(n as i64, 0))
+        }
+    }
+
+    fn from_f64(n: f64) -> Option<Self> {
+        Some(<SciDecimal as From<f64>>::from(n))
+    }
+}
+
+impl ToPrimitive for SciDecimal {
+    fn to_i64(&self) -> Option<i64> {
+        if self.is_infinite() {
+            return None
+        }
+        match self.precision().cmp(&0) {
+            Ordering::Less => {
+                // Significand is guaranteed to not be larger than 10^16 - 1 and
+                // therefore so is the resulting number
+                Some(self.round_precision(0, RoundingMode::HalfEven).significand_signed())
+            },
+            Ordering::Equal => Some(self.significand_signed()),
+            Ordering::Greater => {
+                self.significand_signed().checked_mul(10_i64.pow(self.exponent() as u32))
+            },
+        }
+    }
+
+    #[inline]
+    fn to_u64(&self) -> Option<u64> {
+        if self.is_sign_negative() {
+            if self.is_zero() {
+                return Some(0)
+            } else {
+                return None
+            }
+        }
+        self.to_i64().map(|n| n as u64)
+    }
+}
+
+impl NumCast for SciDecimal {
+    fn from<T: ToPrimitive>(n: T) -> Option<Self> {
+        if let Some(f) = n.to_f64() {
+            Self::from_f64(f)
+        } else if let Some(i) = n.to_i64() {
+            Self::from_i64(i)
+        } else {
+            Self::from_u64(n.to_u64()?)
+        }
+    }
+}
+
+impl FromPrimitive for SciFloat {
+    fn from_i64(n: i64) -> Option<Self> {
+        f64::from_i64(n).map(|f| f.into())
+    }
+
+    fn from_u64(n: u64) -> Option<Self> {
+        f64::from_u64(n).map(|f| f.into())
+    }
+
+    fn from_f64(n: f64) -> Option<Self> {
+        Some(Self::new(n))
+    }
+}
+
+impl ToPrimitive for SciFloat {
+    fn to_i64(&self) -> Option<i64> {
+        self.number().to_i64()
+    }
+
+    fn to_u64(&self) -> Option<u64> {
+        self.number().to_u64()
+    }
+
+    fn to_f64(&self) -> Option<f64> {
+        Some(self.number())
+    }
+}
+
+impl NumCast for SciFloat {
+    fn from<T: ToPrimitive>(n: T) -> Option<Self> {
+        if let Some(f) = n.to_f64() {
+            Self::from_f64(f)
+        } else if let Some(i) = n.to_i64() {
+            Self::from_i64(i)
+        } else {
+            Self::from_u64(n.to_u64()?)
+        }
+    }
+}

--- a/src/cast.rs
+++ b/src/cast.rs
@@ -40,7 +40,7 @@ impl ToPrimitive for SciDecimal {
             Ordering::Less => {
                 // Significand is guaranteed to not be larger than 10^16 - 1 and
                 // therefore so is the resulting number
-                Some(self.round_precision(0, RoundingMode::HalfEven).significand_signed())
+                Some(self.round_precision(0, RoundingMode::HalfUp).significand_signed())
             },
             Ordering::Equal => Some(self.significand_signed()),
             Ordering::Greater => {

--- a/src/decimal.rs
+++ b/src/decimal.rs
@@ -10,7 +10,7 @@ use std::{
 };
 
 use bigdecimal::{BigDecimal, num_bigint::BigInt};
-use num_traits::{FromPrimitive, Inv, Num, One, Pow, Zero};
+use num_traits::{Float, FromPrimitive, Inv, Num, One, Pow, Zero};
 use regex::Regex;
 use rust_decimal::{Decimal, MathematicalOps};
 
@@ -767,26 +767,24 @@ impl Num for SciDecimal {
     }
 }
 
-//impl Float for SciDecimal {
-#[allow(unused)]
-impl SciDecimal {
+impl Float for SciDecimal {
     #[inline]
-    pub fn nan() -> Self {
+    fn nan() -> Self {
         Self::NAN
     }
 
     #[inline]
-    pub fn infinity() -> Self {
+    fn infinity() -> Self {
         Self::INFINITY
     }
 
     #[inline]
-    pub fn neg_infinity() -> Self {
+    fn neg_infinity() -> Self {
         Self::NEG_INFINITY
     }
 
     #[inline]
-    pub fn neg_zero() -> Self {
+    fn neg_zero() -> Self {
         Self::NEG_ZERO
     }
 
@@ -803,27 +801,27 @@ impl SciDecimal {
     }
 
     #[inline]
-    pub fn is_nan(self) -> bool {
+    fn is_nan(self) -> bool {
         self.nan
     }
 
     #[inline]
-    pub fn is_infinite(self) -> bool {
+    fn is_infinite(self) -> bool {
         self.inf
     }
 
     #[inline]
-    pub fn is_finite(self) -> bool {
+    fn is_finite(self) -> bool {
         !(self.inf | self.nan)
     }
 
     #[inline]
-    pub fn is_normal(self) -> bool {
+    fn is_normal(self) -> bool {
         !(self.inf | self.nan | (self.significand == 0))
     }
 
     #[inline]
-    pub fn classify(self) -> FpCategory {
+    fn classify(self) -> FpCategory {
         if self.nan {
             FpCategory::Nan
         } else if self.inf {
@@ -844,7 +842,7 @@ impl SciDecimal {
     }
 
     fn round(self) -> Self {
-        todo!()
+        self.round_precision(0, RoundingMode::HalfEven)
     }
 
     fn trunc(self) -> Self {
@@ -855,7 +853,7 @@ impl SciDecimal {
         todo!()
     }
 
-    pub fn abs(self) -> Self {
+    fn abs(self) -> Self {
         if self.nan {
             Self::NAN
         } else {
@@ -866,7 +864,7 @@ impl SciDecimal {
         }
     }
 
-    pub fn signum(self) -> Self {
+    fn signum(self) -> Self {
         if self.nan {
             Self::NAN
         } else if self.negative {
@@ -880,7 +878,7 @@ impl SciDecimal {
     /// Zero is also considered positive.
     #[inline]
     //#[must_use]
-    pub fn is_sign_positive(self) -> bool {
+    fn is_sign_positive(self) -> bool {
         if self.is_nan() {
             todo!("Special values are not yet handled correctly by this method!")
         }
@@ -891,7 +889,7 @@ impl SciDecimal {
     /// Zero is considered positive.
     #[inline]
     //#[must_use]
-    pub fn is_sign_negative(self) -> bool {
+    fn is_sign_negative(self) -> bool {
         if self.is_nan() {
             todo!("Special values are not yet handled correctly by this method!")
         }
@@ -906,7 +904,7 @@ impl SciDecimal {
 
     /// Takes the reciprocoal (inverse) of the number, `1/x`.
     #[inline]
-    pub fn recip(self) -> Self {
+    fn recip(self) -> Self {
         self.inv()
     }
 
@@ -915,7 +913,7 @@ impl SciDecimal {
     /// # Panics
     ///
     /// This function panics if `n` is not within the range `-127 <= n <= 127`.
-    pub fn powi(self, n: i32) -> Self {
+    fn powi(self, n: i32) -> Self {
         if !self.is_normal() {
             todo!("Special values are not yet handled correctly by this method!")
         }
@@ -938,7 +936,7 @@ impl SciDecimal {
     }
 
     #[inline]
-    pub fn powf(self, n: Self) -> Self {
+    fn powf(self, n: Self) -> Self {
         self.pow(n)
     }
 
@@ -950,7 +948,7 @@ impl SciDecimal {
         todo!()
     }
 
-    pub fn exp(self) -> Self {
+    fn exp(self) -> Self {
         if !self.is_normal() {
             todo!("Special values are not yet handled correctly by this method!")
         }
@@ -967,7 +965,7 @@ impl SciDecimal {
         todo!()
     }
 
-    pub fn ln(self) -> Self {
+    fn ln(self) -> Self {
         if !self.is_normal() {
             todo!("Special values are not yet handled correctly by this method!")
         }
@@ -990,7 +988,7 @@ impl SciDecimal {
         todo!()
     }
 
-    pub fn log10(self) -> Self {
+    fn log10(self) -> Self {
         if !self.is_normal() {
             todo!("Special values are not yet handled correctly by this method!")
         }

--- a/src/decimal.rs
+++ b/src/decimal.rs
@@ -842,7 +842,7 @@ impl Float for SciDecimal {
     }
 
     fn round(self) -> Self {
-        self.round_precision(0, RoundingMode::HalfEven)
+        self.round_precision(0, RoundingMode::HalfUp)
     }
 
     fn trunc(self) -> Self {

--- a/src/decimal.rs
+++ b/src/decimal.rs
@@ -69,6 +69,17 @@ impl SciDecimal {
         significand: u64::MAX,
     };
 
+    /// The smallest supported positive number.
+    pub const MIN_POSITIVE: SciDecimal = SciDecimal {
+        uncertainty: 0,
+        uncertainty_scale: 0,
+        nan: false,
+        inf: false,
+        negative: false,
+        exponent: i16::MIN,
+        significand: 1,
+    };
+
     /// The highest supported number.
     pub const MAX: SciDecimal = SciDecimal {
         uncertainty: 0,
@@ -789,15 +800,15 @@ impl Float for SciDecimal {
     }
 
     fn min_value() -> Self {
-        todo!()
+        Self::MIN
     }
 
     fn min_positive_value() -> Self {
-        todo!()
+        Self::MIN_POSITIVE
     }
 
     fn max_value() -> Self {
-        todo!()
+        Self::MAX
     }
 
     #[inline]

--- a/src/float.rs
+++ b/src/float.rs
@@ -8,7 +8,7 @@ use std::{
     str::FromStr,
 };
 
-use num_traits::{ToPrimitive, FromPrimitive, Float, FloatConst, Inv, Num, One, Pow, Zero};
+use num_traits::{Float, FloatConst, Inv, Num, One, Pow, Zero};
 
 use crate::{RoundingMode, SciDecimal, SciNum, error::SciNumError};
 
@@ -235,9 +235,7 @@ impl Num for SciFloat {
     }
 }
 
-//impl Float for SciFloat {
-#[allow(unused)]
-impl SciFloat {
+impl Float for SciFloat {
     #[inline]
     fn nan() -> Self {
         Self::NAN
@@ -771,26 +769,6 @@ impl FromStr for SciFloat {
             Ok(num) => Ok(SciFloat::new(num)),
             Err(_) => Err(SciNumError::Parse(s.into())),
         }
-    }
-}
-
-impl FromPrimitive for SciFloat {
-    fn from_i64(n: i64) -> Option<Self> {
-        todo!()
-    }
-
-    fn from_u64(n: u64) -> Option<Self> {
-        todo!()
-    }
-}
-
-impl ToPrimitive for SciFloat {
-    fn to_i64(&self) -> Option<i64> {
-        todo!()
-    }
-
-    fn to_u64(&self) -> Option<u64> {
-        todo!()
     }
 }
 

--- a/src/float.rs
+++ b/src/float.rs
@@ -8,7 +8,7 @@ use std::{
     str::FromStr,
 };
 
-use num_traits::{Float, FloatConst, Inv, Num, One, Pow, Zero};
+use num_traits::{ToPrimitive, FromPrimitive, Float, FloatConst, Inv, Num, One, Pow, Zero};
 
 use crate::{RoundingMode, SciDecimal, SciNum, error::SciNumError};
 
@@ -771,6 +771,26 @@ impl FromStr for SciFloat {
             Ok(num) => Ok(SciFloat::new(num)),
             Err(_) => Err(SciNumError::Parse(s.into())),
         }
+    }
+}
+
+impl FromPrimitive for SciFloat {
+    fn from_i64(n: i64) -> Option<Self> {
+        todo!()
+    }
+
+    fn from_u64(n: u64) -> Option<Self> {
+        todo!()
+    }
+}
+
+impl ToPrimitive for SciFloat {
+    fn to_i64(&self) -> Option<i64> {
+        todo!()
+    }
+
+    fn to_u64(&self) -> Option<u64> {
+        todo!()
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@ mod error;
 mod float;
 mod rounding;
 mod scinum;
+pub mod cast;
 
 pub use decimal::SciDecimal;
 pub use error::SciNumError;


### PR DESCRIPTION
Primarily this PR implements `ToPrimitive`, `FromPrimitive`, and `NumCast` for each type (in `cast.rs`), which are the other requirements for `Float` other than the methods.