### PR TITLE
Put both types behind feature gates, only enable scidecimal by default

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,11 @@ version = "0.1.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 
+[features]
+default = ["scidecimal"]
+scidecimal = []
+scifloat = []
+
 [dependencies]
 bigdecimal = "0.4.10"
 num-integer = "0.1.46"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -153,14 +153,20 @@ mod error;
 mod integer;
 mod rounding;
 mod scicast;
-mod scidecimal;
-mod scifloat;
 mod scinum;
 mod uncertainties;
 
 pub use error::SciNumError;
 pub use rounding::RoundingMode;
 pub use scicast::{CheckedSciCast, CheckedSciCastFrom, SciCast, SciCastFrom};
-pub use scidecimal::scidecimal::SciDecimal;
-pub use scifloat::scifloat::SciFloat;
 pub use scinum::SciNum;
+
+#[cfg(feature = "scidecimal")]
+mod scidecimal;
+#[cfg(feature = "scidecimal")]
+pub use scidecimal::scidecimal::SciDecimal;
+
+#[cfg(feature = "scifloat")]
+mod scifloat;
+#[cfg(feature = "scifloat")]
+pub use scifloat::scifloat::SciFloat;

--- a/src/scidecimal/cast.rs
+++ b/src/scidecimal/cast.rs
@@ -7,9 +7,12 @@ use num_traits::{Float, FromPrimitive, NumCast, ToPrimitive, Zero};
 use rust_decimal::Decimal;
 
 use crate::{
-    RoundingMode, SciDecimal, SciFloat, SciNum,
+    RoundingMode, SciDecimal, SciNum,
     scicast::{CheckedSciCast, SciCast},
 };
+
+#[cfg(feature = "scifloat")]
+use crate::SciFloat;
 
 // No-op casting from integers
 
@@ -40,6 +43,7 @@ impl SciCast<SciDecimal> for f64 {
     }
 }
 
+#[cfg(feature = "scifloat")]
 impl SciCast<SciDecimal> for SciFloat {
     fn cast(self) -> SciDecimal {
         self.number()


### PR DESCRIPTION
Closes #23 